### PR TITLE
Update RenderDoc API/platform support

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,8 +271,8 @@
             </tr>
             <tr>
               <th><a href="https://github.com/baldurk/renderdoc">RenderDoc</a></th>
-              <td>Direct3D 11-12, OpenGL 3.2+ core, Vulkan</td>
-              <td>Windows, partial Linux</td>
+              <td>Direct3D 11-12, OpenGL 3.2+ core, OpenGL ES, Vulkan</td>
+              <td>Windows, Linux, Android</td>
             </tr>
             <tr>
               <th><a href="http://code.google.com/p/glintercept/">GLIntercept</a></th>


### PR DESCRIPTION
RenderDoc v1.1 supports GLES on windows & linux, as well as Android (GLES & Vulkan).