### PR TITLE
Add `--recurse-submodules` to git clone example

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,7 +235,7 @@
         </p>
 
         <div class="code panel">
-          git clone https://github.com/apitrace/apitrace
+          git clone --recurse-submodules https://github.com/apitrace/apitrace
         </div>
 
 	<p>Latest Windows binaries are available from <href="https://ci.appveyor.com/project/jrfonseca/apitrace/branch/master">Appveyor</a>:</p>


### PR DESCRIPTION
Initialize and pull submodules on git clone.

Might as well save some people some keystrokes, bafflement, and realization.